### PR TITLE
Re-enable celery

### DIFF
--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,6 +1,7 @@
 
 # Use the Python3.7.2 image
 FROM python:3.7.2-stretch
+ENV FLASK_ENV default
 
 # Set the working directory to /app
 WORKDIR /app

--- a/flask/celery_worker.py
+++ b/flask/celery_worker.py
@@ -1,0 +1,12 @@
+import os
+from dotenv import load_dotenv
+
+# load .env
+dotenv_path = os.path.join(os.path.dirname(__file__), '.flaskenv')
+if os.path.exists(dotenv_path):
+    load_dotenv(dotenv_path, override=True)
+
+from app import create_app, celery
+
+app = create_app(os.environ.get('FLASK_ENV'))
+app.app_context().push()


### PR DESCRIPTION
I don't know the context to remove celery_worker in commit https://github.com/hsuanchi/Max-Newsletter/commit/ff8d0fdf4f20b0d7b040d9a82aa139558c9351ff . However, commit https://github.com/hsuanchi/Max-Newsletter/commit/ff8d0fdf4f20b0d7b040d9a82aa139558c9351ff blocks me to build this project via docker-compose. The error is:

```
$ docker logs 6bf6a082c9fb
Error:                                                                                                
Unable to load celery application.                                                                                                                        
The module celery_worker.celery was not found.
```

I raise this pull request (draft) to create discussion thread. It's fully understood if it is not merged then.