### PR TITLE
docker-compose: create empty db for development

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,19 @@
+# Use the Python3.7.2 image
+FROM python:3.7.2-stretch
+ENV FLASK_ENV default
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Install the dependencies
+ADD requirements.txt /app/requirements.txt
+RUN pip install -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+ADD . /app
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["uwsgi", "app.ini"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Clean the docker containers after completing development
 docker-compose stop ; docker-compose rm -f
 ```
 
+Besides, you may want to clean `flask/migrations/` if you want to re-start from scratch and an empty database for development next time.
+
 
 ##### Dive Into the Code
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,19 +1,24 @@
 version: "3.7"
 
 services:
-
   flask:
-    build: ./flask
+    build:
+      context: ./flask
+      dockerfile: ../Dockerfile-dev
     container_name: flask
-    # restart: always
     environment:
       - APP_NAME=FlaskApp
+      - FLASK_APP=main.py
+      - FLASK_ENV=testing
+      - SECRET_KEY='SOME RANDOM FOR DEVELOPMENT'
     expose:
       - 8080
     depends_on:
       - redis
     volumes:
       - ./flask:/app
+    entrypoint: /docker-entrypoint.sh
+    command: uwsgi app.ini
 
   nginx:
     build: ./nginx

--- a/flask/app/config/config.py
+++ b/flask/app/config/config.py
@@ -101,7 +101,7 @@ class TestingConfig(BaseConfig):
 
     # Flask-sqlalchemy
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(basedir, "test.db")
+    SQLALCHEMY_DATABASE_URI = "sqlite:////tmp/test.db"
 
     # 關閉 CSRF
     WTF_CSRF_ENABLED = False

--- a/flask/docker-entrypoint.sh
+++ b/flask/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+flask db init
+flask db migrate
+flask db upgrade
+
+# refer to docker best practice:
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+# use $@ to get CMD as parameters
+exec "$@"


### PR DESCRIPTION
# Description
By using `docker-compose-dev.yaml`, we could now create a development container with an empty DB.

# Steps to Test This PR
`docker-compose -f docker-compose-dev.yml up --build -d`

# Expected Result
An empty sqlite db `/tmp/test.db`will be created in this container.
