### PR TITLE
build(celery): revivify celery debugging port

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -40,11 +40,24 @@ services:
     build: ./flask
     container_name: celery_worker
     environment:    
-      - CELERY_BROKER_URL=redis://redis:6379/1
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - APP_NAME=FlaskApp
+      - FLASK_APP=main.py
+      - FLASK_ENV=testing
+      - SECRET_KEY='SOME RANDOM FOR DEVELOPMENT AND TESTING'
+      # CELERY_RDB_HOST default is localhost
+      # to allow RDB able to be connected outside the container CELERY_RDB_HOST
+      # is needed to be something else rather than localhost
+      - CELERY_RDB_HOST=0.0.0.0
+    ports:
+      # default debugging port of celery 4.4.7 is 6900 according to official
+      # doc, however the port differs very often and CELERY_RDB_PORT does not
+      # take effect.
+      #
+      # in my case it is usally 6906, and then 6907
+      - "6900-6910:6900-6910"
     depends_on: 
       - redis
-    command: "celery worker -A celery_worker.celery -l INFO"
+    command: "celery worker -A celery_worker.celery -l DEBUG"
 
   celery_beat:
     build: ./flask

--- a/flask/app/config/config.py
+++ b/flask/app/config/config.py
@@ -106,15 +106,18 @@ class TestingConfig(BaseConfig):
     # 關閉 CSRF
     WTF_CSRF_ENABLED = False
 
-    # Cache
-    CACHE_TYPE = 'null'
+    # For testing and/or development only
+    CELERY_BROKER_URL = 'redis://redis:6379/1'
+    CELERY_RESULT_BACKEND = 'redis://redis:6379/2'
+    # default debugging port of celery 4.4.7 is 6900 according to official
+    # doc, however the port differs very often and CELERY_RDB_PORT does not
+    # take effect
+    #
+    # in my case it is usally 6906, and then 6907
+    #CELERY_RDB_PORT = 6900
 
     # Other
     HOST_NAME = 'http://127.0.0.1:5000'
-
-    # PRESERVE_CONTEXT_ON_EXCEPTION = False
-    CELERY_BROKER_URL = 'redis://localhost:6379/0'
-    CELERY_RESULT_BACKEND = 'redis://localhost:6379/1'
 
 
 config = {


### PR DESCRIPTION
In the context of docker containers, localhost means the same container.
In our case, the celery worker is running in another docker container
rather than container flask. This commit revivifies the celery worker
working properly for flask applicatioin.

Besides, this commit also makes the RDB host available outside the
container, so it will be more convenient for debugging.

In the meantime, lets remove variables that we do not actually use.

# Steps to Verify This PR
1. Run docker-compose as usual in testing mode.
2. Subscribe an email address via browser
3. Insert `rdb.set_trace()` in the function `tasks.py::send_check_mail`

# Expected Result
`send_check_mail` will be run by the corresponding celery worker, and the process will wait for your debugging connection. Connect to the worker debugging pdb by `telnet localhost 6906` (or 6907) to access the debugging process.