### PR TITLE
Merge celery containers into flask container

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,7 +10,20 @@ services:
       - APP_NAME=FlaskApp
       - FLASK_APP=main.py
       - FLASK_ENV=testing
-      - SECRET_KEY='SOME RANDOM FOR DEVELOPMENT'
+      - FLASK_DEBUG=true
+      - SECRET_KEY='SOME RANDOM FOR DEVELOPMENT AND TESTING'
+      # CELERY_RDB_HOST default is localhost
+      # to allow RDB able to be connected outside the container CELERY_RDB_HOST
+      # is needed to be something else rather than localhost
+      - CELERY_RDB_HOST=0.0.0.0
+    ports:
+      # default debugging port of celery 4.4.7 is 6900 according to official
+      # doc, however the port differs very often and CELERY_RDB_PORT does not
+      # take effect.
+      #
+      # in my case it is usally 6906, and then 6907
+      - "6900-6910:6900-6910"
+      - "5555:5555"
     expose:
       - 8080
     depends_on:
@@ -35,43 +48,4 @@ services:
     container_name: redis_article
     expose: 
       - 6379
-
-  celery_worker:
-    build: ./flask
-    container_name: celery_worker
-    environment:    
-      - APP_NAME=FlaskApp
-      - FLASK_APP=main.py
-      - FLASK_ENV=testing
-      - SECRET_KEY='SOME RANDOM FOR DEVELOPMENT AND TESTING'
-      # CELERY_RDB_HOST default is localhost
-      # to allow RDB able to be connected outside the container CELERY_RDB_HOST
-      # is needed to be something else rather than localhost
-      - CELERY_RDB_HOST=0.0.0.0
-    ports:
-      # default debugging port of celery 4.4.7 is 6900 according to official
-      # doc, however the port differs very often and CELERY_RDB_PORT does not
-      # take effect.
-      #
-      # in my case it is usally 6906, and then 6907
-      - "6900-6910:6900-6910"
-    depends_on: 
-      - redis
-    command: "celery worker -A celery_worker.celery -l DEBUG"
-
-  celery_beat:
-    build: ./flask
-    container_name: celery_beat
-    depends_on: 
-      - redis
-    command: "celery -A celery_worker.celery beat -l INFO"
-
-  celery_flower:
-    build: ./flask
-    container_name: celery_flower
-    depends_on: 
-      - redis
-    command: "celery flower worker -A celery_worker.celery"
-    ports:
-      - "5555:5555"
 

--- a/flask/docker-entrypoint.sh
+++ b/flask/docker-entrypoint.sh
@@ -3,6 +3,11 @@ flask db init
 flask db migrate
 flask db upgrade
 
+# enable celery worker in the backgroud
+celery worker -A celery_worker.celery -l DEBUG -f /tmp/celery-worker.log &
+celery -A celery_worker.celery beat -l INFO &
+celery flower worker -A celery_worker.celery &
+
 # refer to docker best practice:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 # use $@ to get CMD as parameters


### PR DESCRIPTION
Currently we run each celery service in its own container respectively. This architecture is over-killed in current use cases, and communication between containers may bring in unnecessary complex. This pull request will merge all celery containers into the flask one.

# Steps to Verify This Pull Request
Build dev env with docker compose as usual

# Expected Result
The newsletter flow is working well. (subscription and token verification is working)