### PR TITLE
Fix issue #10 by always providing app object

### DIFF
--- a/flask/main.py
+++ b/flask/main.py
@@ -1,18 +1,16 @@
 import os
 from dotenv import load_dotenv
+from app import create_app, db
+from flask_migrate import Migrate, upgrade, migrate
 
-# load .env
+# load .env and override default env var
 dotenv_path = os.path.join(os.path.dirname(__file__), ".flaskenv")
 if os.path.exists(dotenv_path):
     load_dotenv(dotenv_path, override=True)
 
-    from app import create_app, db
-    from flask_migrate import Migrate, upgrade, migrate
+app = create_app(os.environ.get("FLASK_ENV"))
 
-    app = create_app(os.environ.get("FLASK_ENV"))
-
-    migrates = Migrate(app=app, db=db)
-
+migrates = Migrate(app=app, db=db)
 
 @app.shell_context_processor
 def make_shell_context():


### PR DESCRIPTION
The docker-compose-dev.yaml file is designed as one-line-build. Thus I did not expect any manual configuration file needed to be prepared, including `.flaskenv`. The previous commit 16df6dd27c21c1a9860500160d5969566f481b62 re-formatted `main.py` to conditionally create app instance, and we should guarantee the app object is always provided instead.